### PR TITLE
Another doubled mutex lock and "Consider future as retrieved when continuation has run"

### DIFF
--- a/experimental/future
+++ b/experimental/future
@@ -116,10 +116,12 @@ class asynchronous_state : public std::enable_shared_from_this<asynchronous_stat
 
     void set_exception(std::exception_ptr e)
     {
-      std::lock_guard<std::mutex> guard(mutex_);
+      std::unique_lock<std::mutex> lock(mutex_);
 
       maybe_result_ = expected<T>(e);
 
+      // unlock here so that the async_future passed to the continuation below doesn't block in .get()
+      lock.unlock();
       unsafe_invoke_continuation_if();
     }
 

--- a/experimental/future
+++ b/experimental/future
@@ -168,6 +168,7 @@ class asynchronous_state : public std::enable_shared_from_this<asynchronous_stat
         lock.unlock();
 
         continuation(to_async_future());
+        continuation_complete_  = true;
       }
       else
       {
@@ -178,6 +179,11 @@ class asynchronous_state : public std::enable_shared_from_this<asynchronous_stat
 
     async_future<T> to_async_future();
 
+    bool continuation_complete() const
+    {
+        return continuation_complete_;
+    }
+
   private:
     // invokes the continuation, if it exists
     void unsafe_invoke_continuation_if()
@@ -185,6 +191,7 @@ class asynchronous_state : public std::enable_shared_from_this<asynchronous_stat
       if(continuation_)
       {
         continuation_(to_async_future());
+        continuation_complete_  = true;
       }
     }
 
@@ -195,6 +202,7 @@ class asynchronous_state : public std::enable_shared_from_this<asynchronous_stat
 
     // asynchronous_state may or may not have a continuation stored in it
     hacky_unique_function<void(async_future<T>)> continuation_;
+    bool continuation_complete_ = false;
 };
 
 
@@ -731,7 +739,7 @@ class promise
 
     bool future_retrieved() const
     {
-      return ptr_to_state_.use_count() > 1;
+      return ptr_to_state_.use_count() > 1 or ptr_to_state_->continuation_complete();
     }
 
     bool promise_satisfied() const


### PR DESCRIPTION
I have found another doubled lock, + a little improvement. If you don't like this second commit, I can just drop it from the PR. As you like.